### PR TITLE
fixed ScanObjectNN download

### DIFF
--- a/classification_ScanObjectNN/ScanObjectNN.py
+++ b/classification_ScanObjectNN/ScanObjectNN.py
@@ -12,20 +12,32 @@ from torch.utils.data import Dataset
 os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 
 
+import os
+
 def download():
     BASE_DIR = os.path.dirname(os.path.abspath(__file__))
     DATA_DIR = os.path.join(BASE_DIR, 'data')
-    if not os.path.exists(DATA_DIR):
-        os.mkdir(DATA_DIR)
-    if not os.path.exists(os.path.join(DATA_DIR, 'h5_files')):
-        # note that this link only contains the hardest perturbed variant (PB_T50_RS).
-        # for full versions, consider the following link.
-        www = 'https://github.com/ma-xu/pointMLP-pytorch/releases/download/dataset/h5_files.zip'
-        # www = 'http://103.24.77.34/scanobjectnn/h5_files.zip'
-        zipfile = os.path.basename(www)
-        os.system('wget %s  --no-check-certificate; unzip %s' % (www, zipfile))
-        os.system('mv %s %s' % (zipfile[:-4], DATA_DIR))
-        os.system('rm %s' % (zipfile))
+    H5_DIR = os.path.join(DATA_DIR, 'h5_files')
+    
+    expected_file = os.path.join(H5_DIR, "main_split", "test_objectdataset_augmentedrot_scale75.h5")
+    
+    if os.path.exists(expected_file):
+        print("Dataset already downloaded. Skipping download.")
+        return
+    
+    if not os.path.exists(H5_DIR):
+        os.makedirs(H5_DIR)
+    
+    www = 'https://github.com/ma-xu/pointMLP-pytorch/releases/download/dataset/h5_files.zip'
+    zipfile = os.path.basename(www)
+    
+    os.system(f'wget {www} --no-check-certificate')
+    os.system(f'unzip {zipfile} -d {H5_DIR}')
+    os.system(f'rm {zipfile}')
+    os.system(f'rm -rf "{os.path.join(H5_DIR, "main_files")}"')
+    os.system(f'rm -rf "{os.path.join(H5_DIR, "__MACOSX")}"')
+
+    print("Download and extraction complete.")
 
 
 def load_scanobjectnn_data(partition):


### PR DESCRIPTION
Hi @ma-xu.

- the current downloading & extraction code for ScanObjectNN has a folder name bug and leads to the following error. 
- this PR fixes it 

```
 mv: cannot stat 'h5_files': No such file or directory
Traceback (most recent call last):
  File "main.py", line 251, in <module>
    main()
  File "main.py", line 120, in main
    train_loader = DataLoader(ScanObjectNN(partition='training', num_points=args.num_points), num_workers=args.workers,
  File "/home/amur/pointMLP-pytorch/classification_ScanObjectNN/ScanObjectNN.py", line 59, in __init__
    self.data, self.label = load_scanobjectnn_data(partition)
  File "/home/amur/pointMLP-pytorch/classification_ScanObjectNN/ScanObjectNN.py", line 38, in load_scanobjectnn_data
    f = h5py.File(h5_name, mode="r")
  File "/home/amur/.local/lib/python3.8/site-packages/h5py/_hl/files.py", line 562, in __init__
    fid = make_fid(name, mode, userblock_size, fapl, fcpl, swmr=swmr)
  File "/home/amur/.local/lib/python3.8/site-packages/h5py/_hl/files.py", line 235, in make_fid
    fid = h5f.open(name, flags, fapl=fapl)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5f.pyx", line 102, in h5py.h5f.open
FileNotFoundError: [Errno 2] Unable to synchronously open file (unable to open file: name = '/home/amur/pointMLP-pytorch/classification_ScanObjectNN/data/h5_files/main_split/training_objectdataset_augmentedrot_scale75.h5', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)
```
